### PR TITLE
Configured semantic PR check

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce linting on pull request titles. The workflow ensures that PR titles follow semantic conventions.

* [`.github/workflows/pr-lint.yml`](diffhunk://#diff-96c941d62860ad493e2ef6e2e641b5cdda1373729143a0a72a44f11f46895e4dR1-R20): Added a new workflow named "Lint PR" that triggers on pull request events (`opened`, `edited`, `synchronize`, `reopened`). It uses the `amannn/action-semantic-pull-request` action to validate PR titles for semantic correctness.